### PR TITLE
[#5] 글로벌스타일, 테마 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@chakra-ui/react": "^2.5.1",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
+    "@fontsource/noto-sans-kr": "^4.5.12",
     "@types/node": "^18.14.6",
     "@typescript-eslint/parser": "^5.54.1",
     "axios": "^1.3.4",

--- a/src/components/commons/styles/Theme.ts
+++ b/src/components/commons/styles/Theme.ts
@@ -1,0 +1,9 @@
+import { extendTheme } from '@chakra-ui/react';
+import '@fontsource/noto-sans-kr';
+
+export const theme = extendTheme({
+  fonts: {
+    heading: 'noto-sans-kr',
+    body: 'noto-sans-kr',
+  },
+});

--- a/src/components/commons/styles/Theme.ts
+++ b/src/components/commons/styles/Theme.ts
@@ -2,6 +2,19 @@ import { extendTheme } from '@chakra-ui/react';
 import '@fontsource/noto-sans-kr';
 
 export const theme = extendTheme({
+  colors: {
+    brand: {
+      100: '#BEE3F8',
+      200: '#90CDF4',
+      300: '#63B3ED',
+      400: '#4299E1',
+      500: '#3182CE',
+      600: '#2B6CB0',
+      700: '#2C5282',
+      800: '#2A4365',
+      900: '#1A365D',
+    },
+  },
   fonts: {
     heading: 'noto-sans-kr',
     body: 'noto-sans-kr',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,10 @@
+import { ChakraProvider } from '@chakra-ui/react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { theme } from './components/commons/styles/Theme';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <App />
+  <ChakraProvider resetCSS={true} theme={theme}>
+    <App />
+  </ChakraProvider>
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1255,6 +1255,11 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.35.0.tgz#b7569632b0b788a0ca0e438235154e45d42813a7"
   integrity sha512-JXdzbRiWclLVoD8sNUjR443VVlYqiYmDVT6rGUEIEHU5YJW0gaVZwV2xgM7D4arkvASqD0IlLUVjHiFuxaftRw==
 
+"@fontsource/noto-sans-kr@^4.5.12":
+  version "4.5.12"
+  resolved "https://registry.yarnpkg.com/@fontsource/noto-sans-kr/-/noto-sans-kr-4.5.12.tgz#382d6cdd1928943ca15e80ca013e3b6cf5809f50"
+  integrity sha512-6LBOzXw/V4guB/nATaiUjCcPxwJNGw+ky5DK7/wsgUZvfk8etH9IlKdvjFVidpeCuMVjOdlka2+MEw4hwEHaHA==
+
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.8.tgz#03595ac2075a4dc0f191cc2131de14fbd7d410b9"


### PR DESCRIPTION
fixes #5 
## 내용
- #5 
  - 폰트는 noto sans kr 로 전역 적용하였습니다
  - 라이크어 로컬 브랜드가 파란색 이어서 브랜드 컬러는 파란색으로 적용하였습니다.
  - 브랜드 컬러 사용법은 아래 예시 코드와 https://chakra-ui.com/docs/styled-system/customize-theme 참고해주세요!
```tsx
<Box bg="brand.100">Welcome</Box>
<Button colorScheme='brand'>Click me</Button>
```